### PR TITLE
Replace obsolete Mono implementation with up-to-date .NET one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 target
 .build
 .venv
-.nuget
 __pycache__
 .bundle
 *.o
 main.exe
+/bin
+/obj

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,7 @@ lua:
 	lua main.lua
 
 cs:
-	nuget install -OutputDirectory .nuget Newtonsoft.Json
-	mcs -r:System.Net.Http.dll \
-	-r:.nuget/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll main.cs
-	MONO_PATH=.nuget/Newtonsoft.Json.13.0.3/lib/net45 mono main.exe
+	dotnet run -c Release
 
 perl:
 	cpan Mojolicious

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or in the [web browser](http://localhost:8000/version).
 | python |  3.13 | [main.py](./main.py) | `make python` |
 | pascal/fpc | 3.2.2 | [main.pas](./main.pas) | `make fpc` |
 | lua |  5.4.7 | [main.lua](./main.lua) | `make lua` |
-| csharp/mono | 6.12.0 | [main.cs](./main.cs) | `make cs` |
+| csharp/dotnet | 9.0.0 | [main.cs](./main.cs) | `make cs` |
 | perl | 5.34.1 | [main.pl](./main.pl) | `make perl` |
 
 All implementations above are tested on macOS 15.1 Sequoia.

--- a/main.cs
+++ b/main.cs
@@ -1,44 +1,6 @@
-using System;
-using System.Net;
-using System.Text;
-using Newtonsoft.Json;
-using System.Collections.Generic;
+var builder = WebApplication.CreateBuilder(args);
+builder.Logging.ClearProviders(); // Remove noise
 
-class HttpServer
-{
-    static void Main()
-    {
-        var versionInfo = new Dictionary<string, string> { { "version", "1.0.0" } };
-
-        HttpListener listener = new HttpListener();
-        listener.Prefixes.Add("http://*:8000/");
-        listener.Start();
-        Console.WriteLine("listening on http://localhost:8080");
-
-        while (true)
-        {
-            var context = listener.GetContext();
-            var request = context.Request;
-            var response = context.Response;
-
-            if (request.HttpMethod == "GET" && request.Url.AbsolutePath == "/version")
-            {
-                response.ContentType = "application/json";
-                response.StatusCode = (int)HttpStatusCode.OK;
-
-                var json = JsonConvert.SerializeObject(versionInfo, Formatting.Indented);
-                byte[] buffer = Encoding.UTF8.GetBytes(json);
-                response.ContentLength64 = buffer.Length;
-                response.OutputStream.Write(buffer, 0, buffer.Length);
-            }
-            else
-            {
-                response.StatusCode = (int)HttpStatusCode.NotFound;
-                byte[] buffer = Encoding.UTF8.GetBytes("404 Not Found");
-                response.ContentLength64 = buffer.Length;
-                response.OutputStream.Write(buffer, 0, buffer.Length);
-            }
-            response.OutputStream.Close();
-        }
-    }
-}
+var app = builder.Build();
+app.MapGet("/version", () => new { version = "1.0.0" });
+app.Run("http://localhost:8000");

--- a/main.csproj
+++ b/main.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Current implementation appears to use obsolete Mono which must not be used for new applications.

This PR replaces it with a standard way to quickly serve a JSON with .NET.

This requires having .NET SDK 9.0 installed on the system.

It can be installed with:
- `winget install Microsoft.DotNet.SDK.9`
- `brew install dotnet`
- `sudo apt install dotnet9` (or if `dotnet9` metapackage is not available - `dotnet-sdk-9.0`)